### PR TITLE
Fix handling of multiple blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+-  [(#3)]: Fix handling of multiple mermaid blocks.
+
+  [(#3)]: https://github.com/abhinav/goldmark-mermaid/issues/3
+
 ## [0.1.0] - 2021-04-12
 - Initial release.
 

--- a/testdata/tests.txt
+++ b/testdata/tests.txt
@@ -38,7 +38,7 @@ graph TD;
     C--&gt;D;
 </code></pre>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
-2
+3
 //- - - - - - - - -//
 Does not change other languages.
 
@@ -50,3 +50,35 @@ console.log("hello")
 <pre><code class="language-javascript">console.log(&quot;hello&quot;)
 </code></pre>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+4
+//- - - - - - - - -//
+Supports multiple Mermaid blocks. (#3)
+
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+//- - - - - - - - -//
+<p>Supports multiple Mermaid blocks. (#3)</p>
+<div class="mermaid">graph TD;
+    A--&gt;B;
+    A--&gt;C;
+    B--&gt;D;
+    C--&gt;D;
+</div><div class="mermaid">graph TD;
+    A--&gt;B;
+    A--&gt;C;
+    B--&gt;D;
+    C--&gt;D;
+</div><script src="mermaid.js"></script><script>mermaid.initialize({startOnLoad: true});</script>


### PR DESCRIPTION
It appears that
if we modify the AST with ReplaceChild
while walking it with ast.Walk,
we may end up skipping over sibling nodes.

For example per the report in #3,
with two mermaid blocks next to each other,
we end up replacing the first and skipping the second.

Fix this by collecting all mermaid nodes in one pass,
and replacing them in the second.

Resolves #3
