### PR TITLE
Add <script> tag opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.1] - 2021-11-03
-### Fixed
--  [(#3)]: Fix handling of multiple mermaid blocks.
+## Unreleased
 
-  [(#3)]: https://github.com/abhinav/goldmark-mermaid/issues/3
+### Added
+
+- Support opting out of the MermaidJS `<script>` tag.
+  To use, set `Extender.NoScript` or `Transformer.NoScript` to true.
+  Use this if the page you're rendering into already includes the tag
+  elsewhere.
+
+## [0.1.1] - 2021-11-03
+
+### Fixed
+
+- Fix handling of multiple mermaid blocks.
+
   [0.1.1]: https://github.com/abhinav/goldmark-mermaid/releases/tag/v0.1.1
 
 ## [0.1.0] - 2021-04-12
+
 - Initial release.
 
   [0.1.0]: https://github.com/abhinav/goldmark-mermaid/releases/tag/v0.1.0

--- a/extend.go
+++ b/extend.go
@@ -20,9 +20,17 @@ import (
 //	)
 type Extender struct {
 	// URL of Mermaid Javascript to be included in the page.
+	// Ignored if NoScript is true.
 	//
 	// Defaults to the latest version available on cdn.jsdelivr.net.
 	MermaidJS string
+
+	// If true, don't add a <script> including Mermaid to the end of the
+	// page.
+	//
+	// Use this if the page you're including goldmark-mermaid in
+	// already has a MermaidJS script included elsewhere.
+	NoScript bool
 }
 
 // Extend extends the provided Goldmark parser with support for Mermaid
@@ -30,7 +38,9 @@ type Extender struct {
 func (e *Extender) Extend(md goldmark.Markdown) {
 	md.Parser().AddOptions(
 		parser.WithASTTransformers(
-			util.Prioritized(&Transformer{}, 100),
+			util.Prioritized(&Transformer{
+				NoScript: e.NoScript,
+			}, 100),
 		),
 	)
 	md.Renderer().AddOptions(

--- a/integration_test.go
+++ b/integration_test.go
@@ -18,4 +18,14 @@ func TestIntegration(t *testing.T) {
 		"testdata/tests.txt",
 		t,
 	)
+
+	t.Run("noscript", func(t *testing.T) {
+		testutil.DoTestCaseFile(
+			goldmark.New(goldmark.WithExtensions(&mermaid.Extender{
+				NoScript: true,
+			})),
+			"testdata/tests_noscript.txt",
+			t,
+		)
+	})
 }

--- a/testdata/tests_noscript.txt
+++ b/testdata/tests_noscript.txt
@@ -1,0 +1,52 @@
+1
+//- - - - - - - - -//
+Single mermaid block.
+
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+//- - - - - - - - -//
+<p>Single mermaid block.</p>
+<div class="mermaid">graph TD;
+    A--&gt;B;
+    A--&gt;C;
+    B--&gt;D;
+    C--&gt;D;
+</div>
+//= = = = = = = = = = = = = = = = = = = = = = = =//
+2
+//- - - - - - - - -//
+Multiple mermaid blocks.
+
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+//- - - - - - - - -//
+<p>Multiple mermaid blocks.</p>
+<div class="mermaid">graph TD;
+    A--&gt;B;
+    A--&gt;C;
+    B--&gt;D;
+    C--&gt;D;
+</div><div class="mermaid">graph TD;
+    A--&gt;B;
+    A--&gt;C;
+    B--&gt;D;
+    C--&gt;D;
+</div>

--- a/transform.go
+++ b/transform.go
@@ -13,13 +13,17 @@ import (
 //
 //   - replace mermaid code blocks with mermaid.Block nodes
 //   - add a mermaid.ScriptBlock node if the document uses Mermaid
+//     and one does not already exist
 type Transformer struct {
+	// Don't add a ScriptBlock to the end of the page
+	// even if the page doesn't already have one.
+	NoScript bool
 }
 
 var _mermaid = []byte("mermaid")
 
 // Transform transforms the provided Markdown AST.
-func (*Transformer) Transform(doc *ast.Document, reader text.Reader, pctx parser.Context) {
+func (t *Transformer) Transform(doc *ast.Document, reader text.Reader, pctx parser.Context) {
 	var (
 		hasScript     bool
 		mermaidBlocks []*ast.FencedCodeBlock
@@ -66,7 +70,7 @@ func (*Transformer) Transform(doc *ast.Document, reader text.Reader, pctx parser
 		}
 	}
 
-	if !hasScript {
+	if !hasScript && !t.NoScript {
 		doc.AppendChild(doc, &ScriptBlock{})
 	}
 }

--- a/transform_test.go
+++ b/transform_test.go
@@ -18,6 +18,7 @@ func TestTransformer(t *testing.T) {
 	tests := []struct {
 		desc       string
 		give       string
+		noScript   bool
 		wantBodies []string
 		wantScript bool
 	}{
@@ -55,6 +56,16 @@ func TestTransformer(t *testing.T) {
 			wantBodies: []string{"foo\n"},
 			wantScript: true,
 		},
+		{
+			desc:     "noscript",
+			noScript: true,
+			give: unlines(
+				"```mermaid",
+				"foo",
+				"```",
+			),
+			wantBodies: []string{"foo\n"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -65,7 +76,9 @@ func TestTransformer(t *testing.T) {
 			p := goldmark.New().Parser()
 			p.AddOptions(
 				parser.WithASTTransformers(
-					util.Prioritized(&Transformer{}, 100),
+					util.Prioritized(&Transformer{
+						NoScript: tt.noScript,
+					}, 100),
 				),
 			)
 


### PR DESCRIPTION
Support opting out of `<script>` tag that adds the MermaidJS to the
page.

This should help obviate need to no-op RenderScript that some users have
made.
