### PR TITLE
Renderer => ClientRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Use this if the page you're rendering into already includes the tag
   elsewhere.
 
+### Changed
+
+- Deprecate Renderer in favor of ClientRenderer.
+  Rendere has been aliased to the new type
+  so existing code should continue to work unchanged.
+
 ## [0.1.1] - 2021-11-03
 
 ### Fixed

--- a/client_render.go
+++ b/client_render.go
@@ -10,9 +10,17 @@ import (
 
 const _defaultMermaidJS = "https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"
 
-// Renderer renders Mermaid diagrams as HTML, to be rendered into images
-// client side.
-type Renderer struct {
+// Renderer is the client-side renderer for Mermaid diagrams.
+//
+// Deprecated: Use ClientRenderer.
+type Renderer = ClientRenderer
+
+// ClientRenderer renders Mermaid diagrams as HTML,
+// to be rendered into images client side.
+//
+// It operates by installing a <script> tag into the document
+// that renders the Mermaid diagrams client-side.
+type ClientRenderer struct {
 	// URL of Mermaid Javascript to be included in the page.
 	//
 	// Defaults to the latest version available on cdn.jsdelivr.net.
@@ -21,13 +29,13 @@ type Renderer struct {
 
 // RegisterFuncs registers the renderer for Mermaid blocks with the provided
 // Goldmark Registerer.
-func (r *Renderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+func (r *ClientRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 	reg.Register(Kind, r.Render)
 	reg.Register(ScriptKind, r.RenderScript)
 }
 
 // Render renders mermaid.Block nodes.
-func (*Renderer) Render(w util.BufWriter, src []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+func (*ClientRenderer) Render(w util.BufWriter, src []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	n := node.(*Block)
 	if entering {
 		w.WriteString(`<div class="mermaid">`)
@@ -43,7 +51,7 @@ func (*Renderer) Render(w util.BufWriter, src []byte, node ast.Node, entering bo
 }
 
 // RenderScript renders mermaid.ScriptBlock nodes.
-func (r *Renderer) RenderScript(w util.BufWriter, src []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+func (r *ClientRenderer) RenderScript(w util.BufWriter, src []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	mermaidJS := r.MermaidJS
 	if len(mermaidJS) == 0 {
 		mermaidJS = _defaultMermaidJS

--- a/client_render_test.go
+++ b/client_render_test.go
@@ -49,7 +49,7 @@ func TestRenderer_Block(t *testing.T) {
 
 			r := renderer.NewRenderer(
 				renderer.WithNodeRenderers(
-					util.Prioritized(&Renderer{}, 100),
+					util.Prioritized(&ClientRenderer{}, 100),
 				),
 			)
 
@@ -102,7 +102,7 @@ func TestRenderer_Script(t *testing.T) {
 
 			r := renderer.NewRenderer(
 				renderer.WithNodeRenderers(
-					util.Prioritized(&Renderer{
+					util.Prioritized(&ClientRenderer{
 						MermaidJS: tt.mermaidJS,
 					}, 100),
 				),


### PR DESCRIPTION
Rename Renderer to ClientRenderer,
and add an alias from the old name.
This makes room for the new server-side renderer.
