### PR TITLE
Use vanity import path, release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2022-12-19
+### Changed
+- Change the module path to `go.abhg.dev/goldmark/mermaid`.
+
+### Removed
+- Delete previously deprecated Renderer type.
+  Please use the ClientRenderer instead.
+
+  [0.3.0]: https://github.com/abhinav/goldmark-mermaid/releases/tag/v0.3.0
+
 ## [0.2.0] - 2022-11-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Go Reference](https://pkg.go.dev/badge/github.com/abhinav/goldmark-mermaid.svg)](https://pkg.go.dev/github.com/abhinav/goldmark-mermaid)
+[![Go Reference](https://pkg.go.dev/badge/go.abhg.dev/goldmark/mermaid.svg)](https://pkg.go.dev/go.abhg.dev/goldmark/mermaid)
 [![Go](https://github.com/abhinav/goldmark-mermaid/actions/workflows/go.yml/badge.svg)](https://github.com/abhinav/goldmark-mermaid/actions/workflows/go.yml)
 [![codecov](https://codecov.io/gh/abhinav/goldmark-mermaid/branch/main/graph/badge.svg?token=W98KYF8SPE)](https://codecov.io/gh/abhinav/goldmark-mermaid)
 
@@ -13,7 +13,7 @@ support for [Mermaid] diagrams.
 To use goldmark-mermaid, import the `mermaid` package.
 
 ```go
-import mermaid "github.com/abhinav/goldmark-mermaid"
+import "go.abhg.dev/goldmark/mermaid"
 ```
 
 Then include the `mermaid.Extender` in the list of extensions you build your

--- a/client_render.go
+++ b/client_render.go
@@ -10,11 +10,6 @@ import (
 
 const _defaultMermaidJS = "https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"
 
-// Renderer is the client-side renderer for Mermaid diagrams.
-//
-// Deprecated: Use ClientRenderer.
-type Renderer = ClientRenderer
-
 // ClientRenderer renders Mermaid diagrams as HTML,
 // to be rendered into images client side.
 //

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/abhinav/goldmark-mermaid
+module go.abhg.dev/goldmark/mermaid
 
 go 1.18
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	mermaid "github.com/abhinav/goldmark-mermaid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark"
+	"go.abhg.dev/goldmark/mermaid"
 	"gopkg.in/yaml.v3"
 )
 

--- a/server_render_test.go
+++ b/server_render_test.go
@@ -9,10 +9,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/abhinav/goldmark-mermaid/internal/exectest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark/text"
+	"go.abhg.dev/goldmark/mermaid/internal/exectest"
 )
 
 func TestServerRenderer_Simple(t *testing.T) {

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,4 +1,4 @@
-module github.com/abhinav/goldmark-mermaid/tools
+module go.abhg.dev/goldmark/mermaid/tools
 
 go 1.19
 


### PR DESCRIPTION
Switch to a vanity import path,
delete the previously deprecated Renderer type,
and release 0.3.0.
