### PR TITLE
README: Fix Extender installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ Then include the `mermaid.Extender` in the list of extensions you build your
 
 ```go
 goldmark.New(
-  &mermaid.Extender{}
+  goldmark.WithExtensions(
+    // ...
+    &mermaid.Extender{},
+  ),
   // ...
 ).Convert(src, out)
 ```
@@ -56,9 +59,11 @@ You can pick between the two by setting `RenderMode` on `mermaid.Extender`.
 
 ```go
 goldmark.New(
-  &mermaid.Extender{
-    RenderMode: mermaid.RenderModeServer, // or RenderModeClient
-  }
+  goldmark.WithExtensions(
+    &mermaid.Extender{
+      RenderMode: mermaid.RenderModeServer, // or RenderModeClient
+    },
+  ),
   // ...
 ).Convert(src, out)
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,18 @@
+package mermaid_test
+
+import (
+	"github.com/yuin/goldmark"
+	"go.abhg.dev/goldmark/mermaid"
+)
+
+func ExampleExtender() {
+	goldmark.New(
+		// ...
+		goldmark.WithExtensions(
+			&mermaid.Extender{
+				RenderMode: mermaid.RenderModeServer,
+			},
+			// ...
+		),
+	)
+}

--- a/extend.go
+++ b/extend.go
@@ -13,16 +13,6 @@ import (
 // Extender adds support for Mermaid diagrams to a Goldmark Markdown parser.
 //
 // Use it by installing it to the goldmark.Markdown object upon creation.
-//
-//	goldmark.New(
-//		// ...
-//		goldmark.WithExtensions(
-//			// ...
-//			&mermaid.Exender{
-//				RenderMode: mermaid.ServerRenderMode,
-//			},
-//		),
-//	)
 type Extender struct {
 	// RenderMode specifies which renderer the Extender should install.
 	//


### PR DESCRIPTION
The instructions for using mermaid.Extender
incorrectly neglected to say goldmark.WithExtensions.

Resolves #18
