### PR TITLE
Add demo website

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "daily"
 
+  - package-ecosystem: "gomod"
+    directory: "/demo"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,4 +1,4 @@
-name: Publish API Reference
+name: Publish documentation
 
 on:
   # Publish documentation when a new release is tagged.
@@ -40,6 +40,10 @@ jobs:
         run: go install go.abhg.dev/doc2go@latest
       - name: Generate API reference
         run: doc2go -home go.abhg.dev/goldmark/mermaid  ./...
+      - name: Build demo website
+        run: |
+          make -C demo
+          cp -r demo/static _site/demo
       - name: Upload pages
         uses: actions/upload-pages-artifact@v1
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ support for [Mermaid] diagrams.
   [goldmark]: http://github.com/yuin/goldmark
   [Mermaid]: https://mermaid-js.github.io/mermaid/
 
+**Demo**:
+A web-based demonstration of the extension is available at
+<https://abhinav.github.io/goldmark-mermaid/demo/>.
+
 ## Installation
 
 ```bash

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,0 +1,12 @@
+OUT = static
+
+.PHONY: all
+all: $(OUT)/wasm_exec.js $(OUT)/main.wasm
+
+$(OUT)/wasm_exec.js:
+	@mkdir -p $(OUT)
+	cp "$(shell go env GOROOT)/misc/wasm/wasm_exec.js" $@
+
+$(OUT)/main.wasm: $(wildcard *.go)
+	@mkdir -p $(OUT)
+	GOOS=js GOARCH=wasm go build -o $@

--- a/demo/go.mod
+++ b/demo/go.mod
@@ -1,0 +1,10 @@
+module go.abhg.dev/goldmark/mermaid/demo
+
+go 1.20
+
+replace go.abhg.dev/goldmark/mermaid => ../
+
+require (
+	github.com/yuin/goldmark v1.5.4
+	go.abhg.dev/goldmark/mermaid v0.3.0
+)

--- a/demo/go.sum
+++ b/demo/go.sum
@@ -1,0 +1,6 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/yuin/goldmark v1.5.4 h1:2uY/xC0roWy8IBEGLgB1ywIoEJFGmRrX21YQcvGZzjU=
+github.com/yuin/goldmark v1.5.4/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/demo/main.go
+++ b/demo/main.go
@@ -1,0 +1,35 @@
+// demo implements a WASM module that can be used to format markdown
+// with the goldmark-mermaid extension.
+package main
+
+import (
+	"bytes"
+	"syscall/js"
+
+	"github.com/yuin/goldmark"
+	"go.abhg.dev/goldmark/mermaid"
+)
+
+func main() {
+	js.Global().Set("formatMarkdown", js.FuncOf(formatMarkdown))
+	select {}
+}
+
+func formatMarkdown(this js.Value, args []js.Value) any {
+	input := args[0].String()
+
+	md := goldmark.New(
+		goldmark.WithExtensions(
+			&mermaid.Extender{
+				RenderMode: mermaid.RenderModeClient,
+				NoScript:   true,
+			},
+		),
+	)
+
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(input), &buf); err != nil {
+		return err.Error()
+	}
+	return buf.String()
+}

--- a/demo/static/.gitignore
+++ b/demo/static/.gitignore
@@ -1,0 +1,2 @@
+/wasm_exec.js
+/main.wasm

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>goldmark-mermaid</title>
+    <script src="wasm_exec.js"></script>
+    <script>
+      const go = new Go();
+      WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject).then((result) => {
+        go.run(result.instance);
+      });
+    </script>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+      .container {
+        max-width: 100%;
+        margin: 0 auto;
+        position: relative;
+      }
+      .input-container {
+        border: 1px solid #ccc;
+        padding: 1em;
+        top: 0;
+        left: 0;
+        width: 45%;
+        position: absolute;
+      }
+      .output-container {
+        border: 1px solid #ccc;
+        padding: 1em;
+        top: 0;
+        left: 50%;
+        width: 45%;
+        position: absolute;
+      }
+
+      #input {
+        width: 100%;
+        height: 60vh;
+      }
+    </style>
+  </head>
+  <body>
+    <center>
+      <h1><a href="https://github.com/abhinav/goldmark-mermaid">goldmark-mermaid</a></h1>
+    </center>
+
+    <div class="container">
+      <div class="input-container">
+        <h2>Input</h2>
+        <textarea id="input" rows="10" cols="80">
+# Foo
+
+```mermaid
+graph LR
+  A --&gt; B
+```
+</textarea>
+      </div>
+
+      <div class="output-container">
+        <h2>Output</h2>
+        <div id="output"></div>
+      </div>
+    </div>
+  </body>
+
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+
+    const input = document.getElementById("input");
+    const output = document.getElementById("output");
+    mermaid.initialize();
+
+    input.addEventListener("input", refresh);
+
+    function refresh() {
+      output.innerHTML = formatMarkdown(input.value);
+      mermaid.run();
+    }
+  </script>
+</html>


### PR DESCRIPTION
Adds a demo website to the published documentation.
The website uses WASM to show the effect of the plugin
on a static web page.
