### PR TITLE
ClientRenderer: Use pre instead of div

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- ClientRenderer: Use `<pre>` instead of `<div>` for diagram containers.
+
+### Added
+- ClientRenderer: Support changing the container tag
+  with the `ContainerTag` option.
+
 ## [0.3.0] - 2022-12-19
 ### Changed
 - Change the module path to `go.abhg.dev/goldmark/mermaid`.

--- a/client_render.go
+++ b/client_render.go
@@ -33,14 +33,14 @@ func (r *ClientRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) 
 func (*ClientRenderer) Render(w util.BufWriter, src []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	n := node.(*Block)
 	if entering {
-		w.WriteString(`<div class="mermaid">`)
+		w.WriteString(`<pre class="mermaid">`)
 		lines := n.Lines()
 		for i := 0; i < lines.Len(); i++ {
 			line := lines.At(i)
 			template.HTMLEscape(w, line.Value(src))
 		}
 	} else {
-		w.WriteString("</div>")
+		w.WriteString("</pre>")
 	}
 	return ast.WalkContinue, nil
 }

--- a/client_render_test.go
+++ b/client_render_test.go
@@ -22,22 +22,22 @@ func TestRenderer_Block(t *testing.T) {
 		{
 			desc: "empty",
 			give: "",
-			want: `<div class="mermaid"></div>`,
+			want: `<pre class="mermaid"></pre>`,
 		},
 		{
 			desc: "graph",
 			give: "graph TD;",
-			want: `<div class="mermaid">graph TD;</div>`,
+			want: `<pre class="mermaid">graph TD;</pre>`,
 		},
 		{
 			desc: "newlines",
 			give: unlines("foo", "bar"),
-			want: `<div class="mermaid">foo` + "\nbar" + "\n</div>",
+			want: `<pre class="mermaid">foo` + "\nbar" + "\n</pre>",
 		},
 		{
 			desc: "escaping",
 			give: "A -> B",
-			want: `<div class="mermaid">A -&gt; B</div>`,
+			want: `<pre class="mermaid">A -&gt; B</pre>`,
 		},
 	}
 

--- a/testdata/client.yaml
+++ b/testdata/client.yaml
@@ -11,12 +11,12 @@
     ```
   want: |
     <p>Transforms mermaid blocks.</p>
-    <div class="mermaid">graph TD;
+    <pre class="mermaid">graph TD;
         A--&gt;B;
         A--&gt;C;
         B--&gt;D;
         C--&gt;D;
-    </div><script src="mermaid.js"></script><script>mermaid.initialize({startOnLoad: true});</script>
+    </pre><script src="mermaid.js"></script><script>mermaid.initialize({startOnLoad: true});</script>
 
 - desc: noscript/single block
   noscript: true
@@ -32,12 +32,12 @@
     ```
   want: |
     <p>Single mermaid block.</p>
-    <div class="mermaid">graph TD;
+    <pre class="mermaid">graph TD;
         A--&gt;B;
         A--&gt;C;
         B--&gt;D;
         C--&gt;D;
-    </div>
+    </pre>
 
 - desc: unmarked block
   give: |
@@ -92,17 +92,17 @@
     ```
   want: |
     <p>Supports multiple Mermaid blocks. (#3)</p>
-    <div class="mermaid">graph TD;
+    <pre class="mermaid">graph TD;
         A--&gt;B;
         A--&gt;C;
         B--&gt;D;
         C--&gt;D;
-    </div><div class="mermaid">graph TD;
+    </pre><pre class="mermaid">graph TD;
         A--&gt;B;
         A--&gt;C;
         B--&gt;D;
         C--&gt;D;
-    </div><script src="mermaid.js"></script><script>mermaid.initialize({startOnLoad: true});</script>
+    </pre><script src="mermaid.js"></script><script>mermaid.initialize({startOnLoad: true});</script>
 
 
 - desc: noscript/multiple blocks
@@ -127,14 +127,14 @@
     ```
   want: |
     <p>Supports multiple Mermaid blocks. (#3)</p>
-    <div class="mermaid">graph TD;
+    <pre class="mermaid">graph TD;
         A--&gt;B;
         A--&gt;C;
         B--&gt;D;
         C--&gt;D;
-    </div><div class="mermaid">graph TD;
+    </pre><pre class="mermaid">graph TD;
         A--&gt;B;
         A--&gt;C;
         B--&gt;D;
         C--&gt;D;
-    </div>
+    </pre>


### PR DESCRIPTION
Changes the ClientRenderer to use `<pre>` instead of `<div>`
as this leads to a much nicer degraded user experience
if the script fails to load or hasn't yet loaded.

Since this is a significant change in behavior,
adds a ClientRenderer.ContainerTag option
to let users opt into the old behavior.

Resolves #31